### PR TITLE
Force to use pybind v2.10.1

### DIFF
--- a/src/scripts/install_compile_3rd_party.sh
+++ b/src/scripts/install_compile_3rd_party.sh
@@ -37,7 +37,7 @@ cd /tmp; git clone https://github.com/USCiLab/cereal.git -b v1.3.2 \
     && cmake -DSKIP_PORTABILITY_TEST=1 -DJUST_INSTALL_CEREAL=ON .; sudo make -j$thread install; rm -rf /tmp/cereal;
 
 # Build Pangolin
-cd /tmp; git clone https://github.com/stevenlovegrove/Pangolin.git -b v0.8 --recursive \
+cd /tmp; git clone https://github.com/stevenlovegrove/Pangolin.git -b v0.8 \
     && mkdir Pangolin_Build && cd Pangolin_Build \
     && cmake -DCMAKE_BUILD_TYPE=Release  ../Pangolin/ . \
     && sudo make -j$thread install; sudo cmake --build . -t pypangolin_pip_install;

--- a/src/scripts/install_deps_mac.sh
+++ b/src/scripts/install_deps_mac.sh
@@ -17,9 +17,9 @@
 # Install system deps with Homebrew
 # Toolchains
 brew install cmake doxygen
-# VRS and Pybind11 dependencies
+# VRS dependencies
 brew install boost sophus cereal googletest glog glew lz4 zstd xxhash libpng jpeg-turbo
-# Installing pybind11
+# Installing Python and dependencies
 pip3 install pybind11[global] numpy
 
 # Install and compile libraries


### PR DESCRIPTION
Summary:
Enhance compatibility with Python 3.11 for dependencies
(Pangolin is using pybind11 that got compilation error with Python3.11)

Differential Revision: D41328021

